### PR TITLE
Fixed JSendMixin hanging up if auto_finish was disabled

### DIFF
--- a/tests/test_tornado_json.py
+++ b/tests/test_tornado_json.py
@@ -170,6 +170,9 @@ class TestJSendMixin(TestTornadoJSONBase):
         def write(self, data):
             self._buffer = data
 
+        def finish(self):
+            pass
+
     @classmethod
     @pytest.fixture(scope="class", autouse=True)
     def setup(cls):

--- a/tornado_json/jsend.py
+++ b/tornado_json/jsend.py
@@ -19,6 +19,7 @@ class JSendMixin(object):
             call. If the call returns no data, data should be set to null.
         """
         self.write({'status': 'success', 'data': data})
+        self.finish()
 
     def fail(self, data):
         """There was a problem with the data submitted, or some pre-condition
@@ -30,6 +31,7 @@ class JSendMixin(object):
             the response object's keys SHOULD correspond to those POST values.
         """
         self.write({'status': 'fail', 'data': data})
+        self.finish()
 
     def error(self, message, data=None, code=None):
         """An error occurred in processing the request, i.e. an exception was
@@ -51,3 +53,4 @@ class JSendMixin(object):
         if code:
             result['code'] = code
         self.write(result)
+        self.finish()


### PR DESCRIPTION
If you somehow disable self._auto_finish, JSendMixin hangs the whole thing up because (I think) it relies on auto_finish to finish imidietly after write(), and you disable that, it hangs right after write.
So I fixed it by appending self.finish() after every write in every JSendMixin method. If auto_finish = true, it does nothing, if it's false, it finishes properly.
In my case, I had to disable auto_finish using decorator to implement asynchronous @auth.
