### PR TITLE
Implement tornado_json.gen.coroutine

### DIFF
--- a/demos/helloworld/API_Documentation.md
+++ b/demos/helloworld/API_Documentation.md
@@ -2,7 +2,7 @@
 
 **Output schemas only represent `data` and not the full output; see output examples and the JSend specification.**
 
-# /api/asynchelloworld/?
+# /api/asynchelloworld/\(?P\<name\>\[a\-zA\-Z0\-9\_\]\+\)/?$
 
     Content-Type: application/json
 

--- a/demos/helloworld/API_Documentation.md
+++ b/demos/helloworld/API_Documentation.md
@@ -26,7 +26,7 @@ null
 
 **Output Example**
 ```json
-"Hello (asynchronous) world!"
+"Hello (asynchronous) world! My name is Fred."
 ```
 
 

--- a/demos/helloworld/helloworld/api.py
+++ b/demos/helloworld/helloworld/api.py
@@ -81,11 +81,11 @@ class Greeting(APIHandler):
 class AsyncHelloWorld(APIHandler):
 
     def hello(self, name, callback=None):
-        callback("Hello (asynchronous) world! My name is {}".format(name))
+        callback("Hello (asynchronous) world! My name is {}.".format(name))
 
     @schema.validate(
         output_schema={"type": "string"},
-        output_example="Hello (asynchronous) world!"
+        output_example="Hello (asynchronous) world! My name is Fred."
     )
     # ``tornado_json.gen.coroutine`` must be used for coroutines
     # ``tornado.gen.coroutine`` CANNOT be used directly

--- a/demos/helloworld/helloworld/api.py
+++ b/demos/helloworld/helloworld/api.py
@@ -2,6 +2,7 @@ from tornado import gen
 
 from tornado_json.requesthandlers import APIHandler
 from tornado_json import schema
+from tornado_json.gen import coroutine
 
 
 class HelloWorldHandler(APIHandler):
@@ -18,34 +19,6 @@ class HelloWorldHandler(APIHandler):
     def get(self):
         """Shouts hello to the world!"""
         return "Hello world!"
-
-
-class AsyncHelloWorld(APIHandler):
-
-    def hello(self, callback=None):
-        callback("Hello (asynchronous) world!")
-
-    @schema.validate(
-        output_schema={"type": "string"},
-        output_example="Hello (asynchronous) world!"
-    )
-    @gen.coroutine
-    def get(self):
-        """Shouts hello to the world (asynchronously)!"""
-        # Asynchronously yield a result from a method
-        res = yield gen.Task(self.hello)
-
-        # When using the `schema.validate` decorator asynchronously,
-        #   we can return the output desired by raising
-        #   `tornado.gen.Return(value)` which returns a
-        #   Future that the decorator will yield.
-        # In Python 3.3, using `raise Return(value)` is no longer
-        #   necessary and can be replaced with simply `return value`.
-        #   For details, see:
-        # http://www.tornadoweb.org/en/branch3.2/gen.html#tornado.gen.Return
-
-        # return res  # Python 3.3
-        raise gen.Return(res)  # Python 2.7
 
 
 class PostIt(APIHandler):
@@ -103,6 +76,36 @@ class Greeting(APIHandler):
     def get(self, fname, lname):
         """Greets you."""
         return "Greetings, {} {}!".format(fname, lname)
+
+
+class AsyncHelloWorld(APIHandler):
+
+    def hello(self, name, callback=None):
+        callback("Hello (asynchronous) world! My name is {}".format(name))
+
+    @schema.validate(
+        output_schema={"type": "string"},
+        output_example="Hello (asynchronous) world!"
+    )
+    # ``tornado_json.gen.coroutine`` must be used for coroutines
+    # ``tornado.gen.coroutine`` CANNOT be used directly
+    @coroutine
+    def get(self, name):
+        """Shouts hello to the world (asynchronously)!"""
+        # Asynchronously yield a result from a method
+        res = yield gen.Task(self.hello, name)
+
+        # When using the `schema.validate` decorator asynchronously,
+        #   we can return the output desired by raising
+        #   `tornado.gen.Return(value)` which returns a
+        #   Future that the decorator will yield.
+        # In Python 3.3, using `raise Return(value)` is no longer
+        #   necessary and can be replaced with simply `return value`.
+        #   For details, see:
+        # http://www.tornadoweb.org/en/branch3.2/gen.html#tornado.gen.Return
+
+        # return res  # Python 3.3
+        raise gen.Return(res)  # Python 2.7
 
 
 class FreeWilledHandler(APIHandler):

--- a/docs/using_tornado_json.rst
+++ b/docs/using_tornado_json.rst
@@ -126,7 +126,7 @@ Further Examples
 See `helloworld <https://github.com/hfaran/Tornado-JSON/blob/master/demos/helloworld/helloworld/api.py>`__
 for further RequestHandler examples with features including:
 
-* Asynchronous methods in RequestHandlers
-* POSTing (or PUTing, PATCHing etc.) data; `self.body`
+* Asynchronous methods in RequestHandlers (must use ``tornado_json.gen.coroutine`` rather than ``tornado.gen.coroutine``)
+* POSTing (or PUTing, PATCHing etc.) data; ``self.body``
 * How to generate routes with URL patterns for RequestHandler methods with arguments
 * and possibly more!

--- a/tests/func_test.py
+++ b/tests/func_test.py
@@ -93,12 +93,12 @@ class APIFunctionalTest(AsyncHTTPTestCase):
 
     def test_asynchronous_handler(self):
         r = self.fetch(
-            "/api/asynchelloworld"
+            "/api/asynchelloworld/name"
         )
         self.assertEqual(r.code, 200)
         self.assertEqual(
             jl(r.body)["data"],
-            "Hello (asynchronous) world!"
+            "Hello (asynchronous) world! My name is name."
         )
 
     def test_post_request(self):

--- a/tests/helloworld_API_documentation.md
+++ b/tests/helloworld_API_documentation.md
@@ -2,7 +2,7 @@
 
 **Output schemas only represent `data` and not the full output; see output examples and the JSend specification.**
 
-# /api/asynchelloworld/?
+# /api/asynchelloworld/\(?P\<name\>\[a\-zA\-Z0\-9\_\]\+\)/?$
 
     Content-Type: application/json
 
@@ -26,7 +26,7 @@ null
 
 **Output Example**
 ```json
-"Hello (asynchronous) world!"
+"Hello (asynchronous) world! My name is Fred."
 ```
 
 

--- a/tests/test_tornado_json.py
+++ b/tests/test_tornado_json.py
@@ -48,7 +48,7 @@ class TestRoutes(TestTornadoJSONBase):
         assert sorted(routes.get_routes(
             helloworld)) == sorted([
             ("/api/helloworld/?", helloworld.api.HelloWorldHandler),
-            ("/api/asynchelloworld/?", helloworld.api.AsyncHelloWorld),
+            ("/api/asynchelloworld/(?P<name>[a-zA-Z0-9_]+)/?$", helloworld.api.AsyncHelloWorld),
             ("/api/postit/?", helloworld.api.PostIt),
             ("/api/greeting/(?P<fname>[a-zA-Z0-9_]+)/"
              "(?P<lname>[a-zA-Z0-9_]+)/?$",

--- a/tornado_json/gen.py
+++ b/tornado_json/gen.py
@@ -1,0 +1,13 @@
+import inspect
+
+from tornado import gen
+
+
+def coroutine(func, replace_callback=True):
+    """Tornado-JSON compatible wrapper for tornado.gen.coroutine
+
+    Annotates original argspec.args of ``func`` as attribute ``__argspec_args``
+    """
+    wrapper = gen.coroutine(func, replace_callback)
+    wrapper.__argspec_args = inspect.getargspec(func).args
+    return wrapper

--- a/tornado_json/gen.py
+++ b/tornado_json/gen.py
@@ -4,7 +4,7 @@ from tornado import gen
 
 
 def coroutine(func, replace_callback=True):
-    """Tornado-JSON compatible wrapper for tornado.gen.coroutine
+    """Tornado-JSON compatible wrapper for ``tornado.gen.coroutine``
 
     Annotates original argspec.args of ``func`` as attribute ``__argspec_args``
     """

--- a/tornado_json/routes.py
+++ b/tornado_json/routes.py
@@ -86,7 +86,14 @@ def get_module_routes(module_name, custom_routes=None, exclusions=None):
         """
         wrapped_method = reduce(getattr, [module, cls_name, method_name])
         method = extract_method(wrapped_method)
-        return [a for a in inspect.getargspec(method).args if a not in ["self"]]
+
+        # If using tornado_json.gen.coroutine, original args are annotated...
+        argspec_args = getattr(method, "__argspec_args", None)
+        # otherwise just grab them from the method
+        if argspec_args is None:
+            argspec_args = inspect.getargspec(method).args
+
+        return [a for a in argspec_args if a not in ["self"]]
 
     def generate_auto_route(module, module_name, cls_name, method_name, url_name):
         """Generate URL for auto_route


### PR DESCRIPTION
As a fix for #59, a custom wrapper for the `tornado.gen.coroutine` wrapper has been implemented. This was necessary as we lose the original argspec through it because the wrapper simply has `(*args, **kwargs)` as its signature. Here, we annotate the original argspec as an attribute to the wrapper so it can be referenced later by Tornado-JSON when generating routes.