### PR TITLE
arg_pattern kwarg for get_module_routes() including hyphen

### DIFF
--- a/demos/rest_api/cars/api/__init__.py
+++ b/demos/rest_api/cars/api/__init__.py
@@ -102,15 +102,15 @@ class YearHandler(CarsAPIHandler):
 #     "<class 'cars.api.MakeListHandler'>"
 #   ],
 #   [
-#     "/api/cars/(?P<make>[a-zA-Z0-9_]+)/(?P<model>[a-zA-Z0-9_]+)/?$",
+#     "/api/cars/(?P<make>[a-zA-Z0-9_\-]+)/(?P<model>[a-zA-Z0-9_\-]+)/?$",
 #     "<class 'cars.api.ModelHandler'>"
 #   ],
 #   [
-#     "/api/cars/(?P<make>[a-zA-Z0-9_]+)/(?P<model>[a-zA-Z0-9_]+)/(?P<year>[a-zA-Z0-9_]+)/?$",
+#     "/api/cars/(?P<make>[a-zA-Z0-9_\-]+)/(?P<model>[a-zA-Z0-9_\-]+)/(?P<year>[a-zA-Z0-9_\-]+)/?$",
 #     "<class 'cars.api.YearHandler'>"
 #   ],
 #   [
-#     "/api/cars/(?P<make>[a-zA-Z0-9_]+)/?$",
+#     "/api/cars/(?P<make>[a-zA-Z0-9_\-]+)/?$",
 #     "<class 'cars.api.MakeHandler'>"
 #   ]
 # ]

--- a/tests/helloworld_API_documentation.md
+++ b/tests/helloworld_API_documentation.md
@@ -2,7 +2,7 @@
 
 **Output schemas only represent `data` and not the full output; see output examples and the JSend specification.**
 
-# /api/asynchelloworld/\(?P\<name\>\[a\-zA\-Z0\-9\_\]\+\)/?$
+# /api/asynchelloworld/\(?P\<name\>\[a\-zA\-Z0\-9\_\\\-\]\+\)/?$
 
     Content-Type: application/json
 
@@ -48,7 +48,7 @@ Shouts hello to the world (asynchronously)!
 <br>
 <br>
 
-# /api/greeting/\(?P\<fname\>\[a\-zA\-Z0\-9\_\]\+\)/\(?P\<lname\>\[a\-zA\-Z0\-9\_\]\+\)/?$
+# /api/greeting/\(?P\<fname\>\[a\-zA\-Z0\-9\_\\\-\]\+\)/\(?P\<lname\>\[a\-zA\-Z0\-9\_\\\-\]\+\)/?$
 
     Content-Type: application/json
 

--- a/tests/test_tornado_json.py
+++ b/tests/test_tornado_json.py
@@ -48,21 +48,21 @@ class TestRoutes(TestTornadoJSONBase):
         assert sorted(routes.get_routes(
             helloworld)) == sorted([
             ("/api/helloworld/?", helloworld.api.HelloWorldHandler),
-            ("/api/asynchelloworld/(?P<name>[a-zA-Z0-9_]+)/?$", helloworld.api.AsyncHelloWorld),
+            ("/api/asynchelloworld/(?P<name>[a-zA-Z0-9_\\-]+)/?$", helloworld.api.AsyncHelloWorld),
             ("/api/postit/?", helloworld.api.PostIt),
-            ("/api/greeting/(?P<fname>[a-zA-Z0-9_]+)/"
-             "(?P<lname>[a-zA-Z0-9_]+)/?$",
+            ("/api/greeting/(?P<fname>[a-zA-Z0-9_\\-]+)/"
+             "(?P<lname>[a-zA-Z0-9_\\-]+)/?$",
              helloworld.api.Greeting),
             ("/api/freewilled/?", helloworld.api.FreeWilledHandler)
         ])
         assert sorted(routes.get_routes(
             cars)) == sorted([
             ("/api/cars/?", cars.api.MakeListHandler),
-            ("/api/cars/(?P<make>[a-zA-Z0-9_]+)/(?P<model>[a-zA-Z0-9_]+)/?$",
+            ("/api/cars/(?P<make>[a-zA-Z0-9_\\-]+)/(?P<model>[a-zA-Z0-9_\\-]+)/?$",
              cars.api.ModelHandler),
-            ("/api/cars/(?P<make>[a-zA-Z0-9_]+)/(?P<model>[a-zA-Z0-9_]+)/"
-             "(?P<year>[a-zA-Z0-9_]+)/?$", cars.api.YearHandler),
-            ("/api/cars/(?P<make>[a-zA-Z0-9_]+)/?$", cars.api.MakeHandler),
+            ("/api/cars/(?P<make>[a-zA-Z0-9_\\-]+)/(?P<model>[a-zA-Z0-9_\\-]+)/"
+             "(?P<year>[a-zA-Z0-9_\\-]+)/?$", cars.api.YearHandler),
+            ("/api/cars/(?P<make>[a-zA-Z0-9_\\-]+)/?$", cars.api.MakeHandler),
         ])
 
     def test_gen_submodule_names(self):
@@ -75,11 +75,11 @@ class TestRoutes(TestTornadoJSONBase):
         assert sorted(routes.get_module_routes(
             "cars.api")) == sorted([
             ("/api/cars/?", cars.api.MakeListHandler),
-            ("/api/cars/(?P<make>[a-zA-Z0-9_]+)/(?P<model>[a-zA-Z0-9_]+)/?$",
+            ("/api/cars/(?P<make>[a-zA-Z0-9_\\-]+)/(?P<model>[a-zA-Z0-9_\\-]+)/?$",
              cars.api.ModelHandler),
-            ("/api/cars/(?P<make>[a-zA-Z0-9_]+)/(?P<model>[a-zA-Z0-9_]+)/"
-             "(?P<year>[a-zA-Z0-9_]+)/?$", cars.api.YearHandler),
-            ("/api/cars/(?P<make>[a-zA-Z0-9_]+)/?$", cars.api.MakeHandler),
+            ("/api/cars/(?P<make>[a-zA-Z0-9_\\-]+)/(?P<model>[a-zA-Z0-9_\\-]+)/"
+             "(?P<year>[a-zA-Z0-9_\\-]+)/?$", cars.api.YearHandler),
+            ("/api/cars/(?P<make>[a-zA-Z0-9_\\-]+)/?$", cars.api.MakeHandler),
         ])
 
 

--- a/tornado_json/routes.py
+++ b/tornado_json/routes.py
@@ -41,7 +41,8 @@ def gen_submodule_names(package):
         yield modname
 
 
-def get_module_routes(module_name, custom_routes=None, exclusions=None):
+def get_module_routes(module_name, custom_routes=None, exclusions=None,
+                      arg_pattern=r'(?P<{}>[a-zA-Z0-9_\-]+)'):
     """Create and return routes for module_name
 
     Routes are (url, RequestHandler) tuples
@@ -56,9 +57,10 @@ def get_module_routes(module_name, custom_routes=None, exclusions=None):
         ``/api/helloworld``.
         Additionally, if a method has extra arguments aside from ``self`` in
         its signature, routes with URL patterns will be generated to
-        match ``r"(?P<{}>[a-zA-Z0-9_]+)".format(argname)`` for each
+        match ``r"(?P<{}>[a-zA-Z0-9_\-]+)".format(argname)`` for each
         argument. The aforementioned regex will match ONLY values
-        with alphanumeric+underscore characters.
+        with alphanumeric, hyphen and underscore characters. You can provide
+        your own pattern by setting a ``arg_pattern`` param.
     :rtype: [(url, RequestHandler), ... ]
     :type  module_name: str
     :param module_name: Name of the module to get routes for
@@ -68,6 +70,8 @@ def get_module_routes(module_name, custom_routes=None, exclusions=None):
     :type  exclusions: [str, str, ...]
     :param exclusions: List of RequestHandler names that routes should not be
         generated for
+    :type  arg_pattern: str
+    :param arg_pattern: Default pattern for extra arguments of any method
     """
     def has_method(module, cls_name, method_name):
         return all([
@@ -126,7 +130,7 @@ def get_module_routes(module_name, custom_routes=None, exclusions=None):
             """
             if yield_args(module, cls_name, method_name):
                 return "/{}/?$".format("/".join(
-                    ["(?P<{}>[a-zA-Z0-9_]+)".format(argname) for argname
+                    [arg_pattern.format(argname) for argname
                      in yield_args(module, cls_name, method_name)]
                 ))
             return r"/?"


### PR DESCRIPTION
Parametrization of the regex, add hyphen (`-`).