### PR TITLE
Add generate_docs parameter to Application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.egg
 *.EGG
 *.EGG-INFO
+.cache
 bin
 build
 develop-eggs

--- a/demos/helloworld/API_Documentation.md
+++ b/demos/helloworld/API_Documentation.md
@@ -2,7 +2,7 @@
 
 **Output schemas only represent `data` and not the full output; see output examples and the JSend specification.**
 
-# /api/asynchelloworld/\(?P\<name\>\[a\-zA\-Z0\-9\_\]\+\)/?$
+# /api/asynchelloworld/\(?P\<name\>\[a\-zA\-Z0\-9\_\\\-\]\+\)/?$
 
     Content-Type: application/json
 
@@ -48,7 +48,7 @@ Shouts hello to the world (asynchronously)!
 <br>
 <br>
 
-# /api/greeting/\(?P\<fname\>\[a\-zA\-Z0\-9\_\]\+\)/\(?P\<lname\>\[a\-zA\-Z0\-9\_\]\+\)/?$
+# /api/greeting/\(?P\<fname\>\[a\-zA\-Z0\-9\_\\\-\]\+\)/\(?P\<lname\>\[a\-zA\-Z0\-9\_\\\-\]\+\)/?$
 
     Content-Type: application/json
 

--- a/demos/helloworld/helloworld.py
+++ b/demos/helloworld/helloworld.py
@@ -24,7 +24,7 @@ def main():
         indent=2)
     )
     # Create the application by passing routes and any settings
-    application = Application(routes=routes, settings={})
+    application = Application(routes=routes, settings={}, generate_docs=True)
 
     # Start the application on port 8888
     application.listen(8888)

--- a/demos/helloworld/helloworld.py
+++ b/demos/helloworld/helloworld.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 
 # ---- The following so demo can be run without having to install package ----#
 import sys

--- a/tornado_json/application.py
+++ b/tornado_json/application.py
@@ -15,11 +15,16 @@ class Application(tornado.web.Application):
     :type  settings: dict
     :param settings: Settings for the app
     :param  db_conn: Database connection
+    :param bool generate_docs: If set, will generate API documentation for
+        provided ``routes``. Documentation is written as API_Documentation.md
+        in the cwd.
     """
 
-    def __init__(self, routes, settings, db_conn=None):
-        # Generate API Documentation
-        api_doc_gen(routes)
+    def __init__(self, routes, settings, db_conn=None,
+                 generate_docs=False):
+        if generate_docs:
+            # Generate API Documentation
+            api_doc_gen(routes)
 
         # Unless compress_response was specifically set to False in
         # settings, enable it

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34}-tornado{311,402}
+envlist = {py27,py35}-tornado{311,402}
 
 [testenv]
 deps=


### PR DESCRIPTION
Introduces a `generate_docs` flag to `Application`. By default, documentation will *not* be generated.

resolves #62 