### PR TITLE
Remove pyclbr and use inspect instead for module introspection

### DIFF
--- a/tornado_json/routes.py
+++ b/tornado_json/routes.py
@@ -1,4 +1,3 @@
-import pyclbr
 import pkgutil
 import importlib
 import inspect
@@ -152,8 +151,8 @@ def get_module_routes(module_name, custom_routes=None, exclusions=None,
     # Generate list of RequestHandler names in custom_routes
     custom_routes_s = [c.__name__ for r, c in custom_routes]
 
-    # rhs is a dict of {classname: pyclbr.Class} key, value pairs
-    rhs = pyclbr.readmodule(module_name)
+    rhs = {cls_name: cls for (cls_name, cls) in
+           inspect.getmembers(module, inspect.isclass)}
 
     # You better believe this is a list comprehension
     auto_routes = list(chain(*[

--- a/tornado_json/utils.py
+++ b/tornado_json/utils.py
@@ -1,5 +1,5 @@
 import collections
-import pyclbr
+import inspect
 import types
 from functools import wraps
 
@@ -58,19 +58,14 @@ def is_method(method):
 
 
 def is_handler_subclass(cls, classnames=("ViewHandler", "APIHandler")):
-    """Determines if ``cls`` is indeed a subclass of ``classnames``
-
-    This function should only be used with ``cls`` from ``pyclbr.readmodule``
-    """
-    if isinstance(cls, pyclbr.Class):
-        return is_handler_subclass(cls.super)
-    elif isinstance(cls, list):
-        return any(is_handler_subclass(s) for s in cls)
-    elif isinstance(cls, str):
-        return cls in classnames
+    """Determines if ``cls`` is indeed a subclass of ``classnames``"""
+    if isinstance(cls, list):
+        return any(is_handler_subclass(c) for c in cls)
+    elif isinstance(cls, type):
+        return any(c.__name__ in classnames for c in inspect.getmro(cls))
     else:
         raise TypeError(
-            "Unexpected pyclbr.Class.super type `{}` for class `{}`".format(
+            "Unexpected type `{}` for class `{}`".format(
                 type(cls),
                 cls
             )


### PR DESCRIPTION
This is being replaced due to pyclbr being broken in Python 3.5 for our use case. Inspect works just as well for what we need.

Resolves #96 