### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 [![Documentation Status](https://readthedocs.org/projects/tornado-json/badge/?version=latest)](https://readthedocs.org/projects/tornado-json/?badge=latest)
 [![Stories in Ready](https://badge.waffle.io/hfaran/Tornado-JSON.png?label=In_Progress)](http://waffle.io/hfaran/Tornado-JSON)
 
-[![Latest Version](https://pypip.in/version/Tornado-JSON/badge.svg)](https://pypi.python.org/pypi/Tornado-JSON/)
-[![Downloads](https://pypip.in/download/Tornado-JSON/badge.svg)](https://pypi.python.org/pypi/Tornado-JSON/)
-[![Supported Python versions](https://pypip.in/py_versions/Tornado-JSON/badge.svg)](https://pypi.python.org/pypi/Tornado-JSON/)
-[![Development Status](https://pypip.in/status/Tornado-JSON/badge.svg)](https://pypi.python.org/pypi/Tornado-JSON/)
-[![Download format](https://pypip.in/format/Tornado-JSON/badge.svg)](https://pypi.python.org/pypi/Tornado-JSON/)
-[![License](https://pypip.in/license/Tornado-JSON/badge.svg)](https://pypi.python.org/pypi/Tornado-JSON/)
+[![Latest Version](https://img.shields.io/pypi/v/Tornado-JSON.svg)](https://pypi.python.org/pypi/Tornado-JSON/)
+[![Downloads](https://img.shields.io/pypi/dm/Tornado-JSON.svg)](https://pypi.python.org/pypi/Tornado-JSON/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/Tornado-JSON.svg)](https://pypi.python.org/pypi/Tornado-JSON/)
+[![Development Status](https://img.shields.io/pypi/status/Tornado-JSON.svg)](https://pypi.python.org/pypi/Tornado-JSON/)
+[![Download format](https://img.shields.io/pypi/format/Tornado-JSON.svg)](https://pypi.python.org/pypi/Tornado-JSON/)
+[![License](https://img.shields.io/pypi/l/Tornado-JSON.svg)](https://pypi.python.org/pypi/Tornado-JSON/)
 
 
 ## Overview


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20tornado-json))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `tornado-json`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.