### PR TITLE
Revert "DeprecationWarning for inspect.getargspec() Fix"

### DIFF
--- a/tornado_json/gen.py
+++ b/tornado_json/gen.py
@@ -15,5 +15,5 @@ def coroutine(func, replace_callback=True):
         wrapper = gen.coroutine(func)
     else:
         wrapper = gen.coroutine(func, replace_callback)
-    wrapper.__argspec_args = inspect.getfullargspec(func).args
+    wrapper.__argspec_args = inspect.getargspec(func).args
     return wrapper

--- a/tornado_json/routes.py
+++ b/tornado_json/routes.py
@@ -93,7 +93,7 @@ def get_module_routes(module_name, custom_routes=None, exclusions=None,
         # If using tornado_json.gen.coroutine, original args are annotated...
         argspec_args = getattr(method, "__argspec_args",
                                # otherwise just grab them from the method
-                               inspect.getfullargspec(method).args)
+                               inspect.getargspec(method).args)
 
         return [a for a in argspec_args if a not in ["self"]]
 


### PR DESCRIPTION
Reverts hfaran/Tornado-JSON#106

@digitaldavenyc I didn't realize it since for some reason Travis CI isn't commenting on PRs anymore, but your PR broke the build for Python 2.7 - getfullargspec doesn't exist there. Please feel free to resubmit this if your change works in both py27 and py3 as well.