### PR TITLE
Add support for async def

### DIFF
--- a/tornado_json/schema.py
+++ b/tornado_json/schema.py
@@ -8,6 +8,11 @@ import tornado.gen
 from tornado_json.exceptions import APIError
 
 try:
+    from asyncio import iscoroutine
+except ImportError:
+    iscoroutine = lambda x: False
+
+try:
     from tornado.concurrent import is_future
 except ImportError:
     # For tornado 3.x.x
@@ -159,8 +164,8 @@ def validate(input_schema=None, output_schema=None,
             # Call the requesthandler method
             output = rh_method(self, *args, **kwargs)
             # If the rh_method returned a Future a la `raise Return(value)`
-            #   we grab the output.
-            if is_future(output):
+            #   or a python 3 coroutine we grab the output.
+            if is_future(output) or iscoroutine(output):
                 output = yield output
 
             # if output is empty, auto return the error 404.


### PR DESCRIPTION
This fixes the `TypeError: Object of type 'coroutine' is not JSON serializable` found when running Tornado 6.0 and using python 3 async def methods.